### PR TITLE
resolve API disconnects

### DIFF
--- a/Ecobee.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/Ecobee.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -84,7 +84,7 @@ class Plugin(indigo.PluginBase):
 			self.pluginPrefs[ACCESS_TOKEN_PLUGIN_PREF] = self.ecobee.access_token
 			self.pluginPrefs[AUTHORIZATION_CODE_PLUGIN_PREF] = self.ecobee.authorization_code
 			self.pluginPrefs[REFRESH_TOKEN_PLUGIN_PREF] = self.ecobee.refresh_token
-		else:
+		if self.ecobee.refresh_token == '':
 			self.pluginPrefs[ACCESS_TOKEN_PLUGIN_PREF] = ''
 			self.pluginPrefs[AUTHORIZATION_CODE_PLUGIN_PREF] = ''
 			self.pluginPrefs[REFRESH_TOKEN_PLUGIN_PREF] = ''


### PR DESCRIPTION
This change resolves the plugin disconnecting from the Ecobee servers.  With the current code, any time the Ecobee API servers are offline (for maintenance, network errors, etc.) the refresh and access token are erased.  This prevents the plugin from making any future updates without reauthentication.

Instead the tokens shouldn't be removed so the plugin can keep trying to refresh.  The access token should only be cleared once the refresh_token is missing.  I have been successfully running with this change for ~4 months.
